### PR TITLE
Fix text garbling when the .notdef glyph is used

### DIFF
--- a/Source/WebCore/platform/graphics/haiku/FontHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/FontHaiku.cpp
@@ -87,12 +87,16 @@ void FontCascade::drawGlyphs(GraphicsContext& graphicsContext, const Font& font,
     BString utf8;
     float offset = point.x();
     for (int i = 0; i < numGlyphs; i++) {
+        Glyph glyph = glyphs[i];
+        if (glyph == 0)
+            glyph = 0xfdd1;
+
         offsets[i].x = offset;
         offsets[i].y = point.y();
         offset += advances[i].width();
 
         char* tmp = buffer;
-        BUnicodeChar::ToUTF8(glyphs[i], &tmp);
+        BUnicodeChar::ToUTF8(glyph, &tmp);
         utf8.Append(buffer, tmp - buffer);
     }
 

--- a/Source/WebCore/platform/graphics/haiku/SimpleFontDataHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/SimpleFontDataHaiku.cpp
@@ -98,6 +98,9 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
     if (!font)
         return FloatRect();
 
+    if (glyph == 0)
+        glyph = 0xfdd1;
+
     BRect rect;
     char string[5] = { 0 };
     char* ptr = string;
@@ -108,8 +111,11 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
 
 float Font::platformWidthForGlyph(Glyph glyph) const
 {
-    if (!glyph || !platformData().size())
+    if (!platformData().size())
         return 0;
+
+    if (glyph == 0)
+        glyph = 0xfdd1;
 
     float escapements[1];
     char string[5] = { 0 };


### PR DESCRIPTION
After f1c80ff75 the .notdef glyph may be requested on purpose. That's
unfortunate for us because we map glyphs to Unicode characters, there's
no character for that, its code is 0 and it becomes a NULL character
that is not added to the string, making advances out of sync.

The purpose of the change was to force some control characters to be
visible, so instead of removing it and align advances, we replace it
with U+FFD1, which is defined as a noncharacter available to programmers
for internal processing purposes. Except for special purpose fonts, it
shouldn't have a glyph to draw, so the font backend will use .notdef in
the end.

Fixes https://dev.haiku-os.org/ticket/17258