### PR TITLE
ExecutableAllocator: Do not store things in g_config when USE(SYSTEM_…

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -403,7 +403,7 @@ static ALWAYS_INLINE JITReservation initializeJITPageReservation()
         g_jscConfig.startExecutableMemory = tagCodePtr<ExecutableMemoryPtrTag>(reservation.base);
         g_jscConfig.endExecutableMemory = tagCodePtr<ExecutableMemoryPtrTag>(reservationEnd);
 
-#if ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
+#if !USE(SYSTEM_MALLOC) && ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)
         WebConfig::g_config[0] = bitwise_cast<uintptr_t>(reservation.base);
         WebConfig::g_config[1] = bitwise_cast<uintptr_t>(reservationEnd);
 #endif


### PR DESCRIPTION
…MALLOC).

Following 41bdcb765f0f1e658c943b2bbf778e8b33fb783b, two additional slots were added
to g_config in order to store these pointers for use in bmalloc and Gigacage. However, when
USE(SYSTEM_MALLOC) is enabled, there are no slots reserved for Gigacage, and so this collided
with g_wtfConfig and overwrote data there instead.

This should fix crashes seen on Haiku, which enables USE(SYSTEM_MALLOC).