### PR TITLE
Sync view and graphics context state on creation

### DIFF
--- a/Source/WebCore/platform/graphics/haiku/GraphicsContextHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/GraphicsContextHaiku.cpp
@@ -52,9 +52,19 @@ namespace WebCore {
 
 
 GraphicsContextHaiku::GraphicsContextHaiku(BView* view)
-    : m_view(view)
+    : GraphicsContext({
+        GraphicsContextState::Change::StrokeThickness,
+        GraphicsContextState::Change::StrokeBrush,
+        GraphicsContextState::Change::Alpha,
+        GraphicsContextState::Change::StrokeStyle,
+        GraphicsContextState::Change::FillBrush,
+        GraphicsContextState::Change::FillRule,
+        GraphicsContextState::Change::CompositeMode,
+    })
+    , m_view(view)
     , m_strokeStyle(B_SOLID_HIGH)
 {
+    didUpdateState(m_state);
 }
 
 GraphicsContextHaiku::~GraphicsContextHaiku()


### PR DESCRIPTION
The GraphicsContextState does not have the same default values as our view, so we may use the wrong ones. For an example, notice the lack of black areas when opening Haiku's [lion.svg test](https://github.com/haiku/haiku/blob/master/src/tests/kits/interface/picture/lion.svg).

The call to `didUpdateState` does not seem to be strictly necessary, as webkit is quite spammy calling that by itself even with no changes, but that may change in the future.

Another thing that seems to work is setting the change flags unconditionally as is done for Cairo ([here](https://github.com/haiku/haikuwebkit/blob/c7f2d7a6f4cd17d7b453523302e45e3d48bc93a5/Source/WebCore/platform/graphics/GraphicsContextState.h#L144) nad  [here](https://github.com/haiku/haikuwebkit/blob/c7f2d7a6f4cd17d7b453523302e45e3d48bc93a5/Source/WebCore/platform/graphics/GraphicsContextState.h#L155)), but that again does not look safe and clean.