### PR TITLE
Fix infinite loop when loading pages

### DIFF
--- a/Source/WebKitLegacy/haiku/API/WebFramePrivate.h
+++ b/Source/WebKitLegacy/haiku/API/WebFramePrivate.h
@@ -55,13 +55,7 @@ public:
     WTF::String requestedURL;
     WebCore::HTMLFrameOwnerElement* ownerElement;
     WebCore::Page* page;
-    // NOTE: We don't keep a reference pointer for the WebCore::Frame, since
-    // that will leave us with one too many references, which will in turn
-    // prevent the shutdown mechanism from working, since that one is only
-    // triggered from the FrameLoader destructor, i.e. when there are no more
-    // references around. (FrameLoader and Frame used to be one class, they
-    // can be considered as one object as far as object life-time goes.)
-    WebCore::Frame* frame;
+    RefPtr<WebCore::Frame> frame;
 };
 
 #endif // WebFramePrivate_h


### PR DESCRIPTION
Remove code that isn't in the windows version of WebKitLegacy. However this is not sufficient, the infinite loop is gone but now we get a crash in BReferenceable at exit because some objects are still being referenced.