### PR TITLE
ImageBuffer: sync view on image copy

### DIFF
--- a/Source/WebCore/platform/graphics/haiku/ImageBufferHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/ImageBufferHaiku.cpp
@@ -88,6 +88,9 @@ ImageBufferData::~ImageBufferData()
 
 WTF::RefPtr<WebCore::NativeImage> ImageBufferHaikuSurfaceBackend::copyNativeImage(WebCore::BackingStoreCopy doCopy) const
 {
+    if (m_data.m_view)
+        m_data.m_view->Sync();
+
     if (doCopy == DontCopyBackingStore) {
         PlatformImagePtr ref = m_data.m_image;
         return NativeImage::create(std::move(ref));


### PR DESCRIPTION
Brings back the gradient for not-hovered items in the menu bar in https://dev.haiku-os.org/.

Bisecting pointed to 5726cb78f5, where copyImage is devirtualized and calls copyNativeImage, so we lost our Sync. I don't know whether that is needed for both doCopy cases (putting it in the DontCopyBackingStore route seems to be enough) and why it wasn't needed before there.