### PR TITLE
Fix minor issues with debug build

### DIFF
--- a/Source/WebCore/platform/haiku/LoggingHaiku.cpp
+++ b/Source/WebCore/platform/haiku/LoggingHaiku.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 
 String logLevelString()
 {
-    return getenv("WEBKIT_DEBUG");
+    return String::fromUTF8(getenv("WEBKIT_DEBUG"));
 }
 
 } // namespace WebCore

--- a/Source/WebKitLegacy/haiku/API/WebPage.cpp
+++ b/Source/WebKitLegacy/haiku/API/WebPage.cpp
@@ -179,7 +179,7 @@ void WebKitInitializeLogChannelsIfNecessary();
 	// NOTE: This needs to be called when the BApplication is ready.
 	// It won't work as static initialization.
 #if !LOG_DISABLED
-    logChannels().initializeLogChannelsIfNecessary("all=all");
+    logChannels().initializeLogChannelsIfNecessary(String::fromUTF8("all=all"));
     WebKitInitializeLogChannelsIfNecessary();
 #endif
     PlatformStrategiesHaiku::initialize();

--- a/Source/WebKitLegacy/haiku/WebCoreSupport/FullscreenVideoController.cpp
+++ b/Source/WebKitLegacy/haiku/WebCoreSupport/FullscreenVideoController.cpp
@@ -279,8 +279,6 @@ void FullscreenVideoController::enterFullscreen()
 
 void FullscreenVideoController::exitFullscreen()
 {
-    ASSERT(!IsWindow(m_hudWindow));
-
     // We previously ripped the videoElement's platform layer out
     // of its orginial layer tree to display it in our fullscreen
     // window.  Now, we need to get the layer back in its original


### PR DESCRIPTION
Source/WebCore/platform/haiku/LoggingHaiku.cpp:
Source/WebKitLegacy/haiku/API/WebPage.cpp:
* There is no converting constructor in WTF::String for const char*, so use String::fromUTF8.

Source/WebKitLegacy/haiku/WebCoreSupport/FullscreenVideoController.cpp:
* FullscreenVideoController::exitFullscreen() had an assert for a member variable that no longer exists. Deleted this assertion.