### PR TITLE
Fix saving META:url attribute on downloads

### DIFF
--- a/Source/WebKitLegacy/haiku/API/WebDownloadPrivate.cpp
+++ b/Source/WebKitLegacy/haiku/API/WebDownloadPrivate.cpp
@@ -233,18 +233,20 @@ void WebDownloadPrivate::setProgressListener(const BMessenger& listener)
 
 void WebDownloadPrivate::handleFinished(WebCore::ResourceHandle* handle, uint32 /*status*/)
 {
+#if USE(CURL)
+    BNode node(m_path.Path());
+    node.WriteAttrString("META:url", &m_url);
+#endif
+
     if (m_mimeTypeGuessTries != -1 && m_mimeType.Length() > 0) {
         // In last resort, use the MIME type provided
         // by the response, which pass our validation
 #if USE(CURL)
-        BNode node(m_filename);
         BNodeInfo info(&node);
-        info.SetType(m_mimeType);
-        node.WriteAttrString("META:url", &m_url);
 #else
         BNodeInfo info(&m_file);
-        info.SetType(m_mimeType);
 #endif
+        info.SetType(m_mimeType);
     }
 
     if (m_progressListener.IsValid()) {


### PR DESCRIPTION
m_filename contains just the file name, not the full path, so the Node creation failed.
We should also set it even if we don't have a mime type.

Fixes https://dev.haiku-os.org/ticket/18227