### PR TITLE
Fit images to window size

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5946,6 +5946,7 @@ ShrinksStandaloneImagesToFit:
   status: embedder
   defaultValue:
     WebKitLegacy:
+      "PLATFORM(HAIKU)": true
       default: false
     WebKit:
       default: true


### PR DESCRIPTION
Recover the value of ShrinksStandaloneImagesToFit that was lost when the WebPreferences files were unified.

Fixes https://dev.haiku-os.org/ticket/18360