### PR TITLE
Implement (some) clipboard copying

### DIFF
--- a/Source/WebCore/platform/haiku/PasteboardHaiku.cpp
+++ b/Source/WebCore/platform/haiku/PasteboardHaiku.cpp
@@ -418,9 +418,14 @@ Vector<String> Pasteboard::typesSafeForBindings(const String&)
 	return typesForLegacyUnsafeBindings();
 }
 
-void Pasteboard::writeCustomData(const WTF::Vector<PasteboardCustomData>&)
+void Pasteboard::writeCustomData(const WTF::Vector<PasteboardCustomData>& data)
 {
-	notImplemented();
+	if (!data.isEmpty()) {
+		const auto& customData = data[0];
+		customData.forEachPlatformString([this] (auto& type, auto& string) {
+			writeString(type, string);
+		});
+	}
 }
 
 void Pasteboard::read(WebCore::PasteboardFileReader&, std::optional<unsigned long>)


### PR DESCRIPTION
It seems JS copying to clipboard goes through writeCustomData. This change is enough for copy buttons like those in Gerrit or Github to put text in the clipboard.