### PR TITLE
Import commit required to fix error when building haiku-webkit2

### DIFF
--- a/Source/WebCore/xml/XSLTProcessor.h
+++ b/Source/WebCore/xml/XSLTProcessor.h
@@ -61,7 +61,11 @@ public:
 
     void reset();
 
+#if LIBXML_VERSION >= 21200
+    static void parseErrorFunc(void* userData, const xmlError*);
+#else
     static void parseErrorFunc(void* userData, xmlError*);
+#endif
     static void genericErrorFunc(void* userData, const char* msg, ...);
     
     // Only for libXSLT callbacks

--- a/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
+++ b/Source/WebCore/xml/XSLTProcessorLibxslt.cpp
@@ -59,7 +59,11 @@ void XSLTProcessor::genericErrorFunc(void*, const char*, ...)
     // It would be nice to do something with this error message.
 }
 
+#if LIBXML_VERSION >= 21200
+void XSLTProcessor::parseErrorFunc(void* userData, const xmlError* error)
+#else
 void XSLTProcessor::parseErrorFunc(void* userData, xmlError* error)
+#endif
 {
     PageConsoleClient* console = static_cast<PageConsoleClient*>(userData);
     if (!console)


### PR DESCRIPTION
Haiku's version of libxml2 appears to have been updated since previous successful builds, so this commit is required for the branch to build now.

I'm not sure how this cherry pick will affect future merges from upstream. It shouldn't affect them, right?