### PR TITLE
Fix build errors when linking with lld

### DIFF
--- a/Source/cmake/OptionsCommon.cmake
+++ b/Source/cmake/OptionsCommon.cmake
@@ -161,6 +161,16 @@ if (LD_SUPPORTS_DISABLE_NEW_DTAGS)
     string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--disable-new-dtags")
 endif ()
 
+# https://github.com/haikuports/haikuports/issues/10445
+# LLD on Haiku requires a flag to work.
+# It would be nice to put this in OptionsHaiku.cmake, but this has to run
+# before some tests that are performed by this file.
+if (USE_LD_LLD AND HAIKU)
+	string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,-m,elf_x86_64")
+	string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,-m,elf_x86_64")
+	string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,-m,elf_x86_64")
+endif ()
+
 # Prefer thin archives by default if they can be both created by the
 # archiver and read back by the linker.
 if (AR_SUPPORTS_THIN_ARCHIVES AND LD_SUPPORTS_THIN_ARCHIVES)

--- a/Source/cmake/OptionsHaiku.cmake
+++ b/Source/cmake/OptionsHaiku.cmake
@@ -25,6 +25,15 @@ set(ENABLE_WEBKIT_LEGACY ON)
 
 set(USE_ANGLE_EGL OFF)
 
+# LLD complains about multiple definitions in some files, whereas ld doesn't.
+# (These multiple definitions seem to be normal. It seems the Mac and Windows
+# ports have multiple definitions as well)
+if (USE_LD_LLD)
+	string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--allow-multiple-definition")
+	string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--allow-multiple-definition")
+	string(APPEND CMAKE_MODULE_LINKER_FLAGS " -Wl,--allow-multiple-definition")
+endif ()
+
 # To get assertions in release mode, we replace all -DNDEBUG with -UNDEBUG
 # (they are automatically added by CMake and there is no "release with asserts"
 # build available in WebKit)


### PR DESCRIPTION
To test:
1. Install llvm17_lld
2. Rerun cmake
3. Check that `USE_LD_LLD` is set to `ON` in the CMakeCache.txt file. If it isn't, then the build system hasn't recognized lld for some reason.
4. Ensure that compiling still works.