### PR TITLE
Fix broken debug build

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -350,7 +350,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
     __builtin_unreachable(); \
 } while (0)
 #elif PLATFORM(HAIKU)
-#define CRASH() (debugger(__PRETTY_FUNCTION__), abort())
+#define CRASH() (::debugger(__PRETTY_FUNCTION__), abort())
 #define CRASH_UNDER_CONSTEXPR_CONTEXT() WTFBreakpointTrapUnderConstexprContext()
 #elif !ENABLE(DEVELOPER_MODE) && !OS(DARWIN)
 #ifdef __cplusplus

--- a/Source/WebCore/platform/haiku/PlatformKeyboardEventHaiku.cpp
+++ b/Source/WebCore/platform/haiku/PlatformKeyboardEventHaiku.cpp
@@ -675,7 +675,7 @@ PlatformKeyboardEvent::PlatformKeyboardEvent(BMessage* message)
 void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCompatibilityMode)
 {
     // Can only change type from KeyDown to RawKeyDown or Char, as we lack information for other conversions.
-    ASSERT(m_type == KeyDown);
+    ASSERT(m_type == PlatformEvent::Type::KeyDown);
     m_type = type;
 
     if (backwardCompatibilityMode)

--- a/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleCurl.cpp
@@ -241,7 +241,7 @@ void ResourceHandle::didReceiveAuthenticationChallenge(const AuthenticationChall
         if (!challenge.previousFailureCount()) {
             Credential credential = d->m_context->storageSession()->credentialStorage().get(partition, challenge.protectionSpace());
             if (!credential.isEmpty() && credential != d->m_initialCredential) {
-                ASSERT(credential.persistence() == CredentialPersistenceNone);
+                ASSERT(credential.persistence() == CredentialPersistence::None);
                 if (challenge.failureResponse().httpStatusCode() == 401) {
                     // Store the credential back, possibly adding it as a default for this directory.
                     d->m_context->storageSession()->credentialStorage().set(partition, credential, challenge.protectionSpace(), challenge.failureResponse().url());


### PR DESCRIPTION
All of the problems come from asserts. I changed debugger to ::debugger since the compiler sometimes thought that line was referencing a function in the local scope, instead of Haiku's debugger. I also fixed some asserts that referenced undefined symbols.