### PR TITLE
Compile NetworkProcess and WebProcess along with MiniBrowser

### DIFF
--- a/Source/WebKit/PlatformHaiku.cmake
+++ b/Source/WebKit/PlatformHaiku.cmake
@@ -93,6 +93,10 @@ if (USE_TEXTURE_MAPPER)
     )
 endif ()
 
+# TODO: It seems not all of these headers should be public. Currently, if a
+# program such as MiniBrowser links against WebKit, all of these directories
+# will be added to the include path of that program.
+# See also https://github.com/webkit/webkit/commit/8da564110578
 list(APPEND WebKit_INCLUDE_DIRECTORIES
     "${DERIVED_SOURCES_HAIKU_API_DIR}"
     "${WEBKIT_DIR}/NetworkProcess/curl"

--- a/Source/WebKit/UIProcess/Launcher/haiku/ProcessLauncherHaiku.cpp
+++ b/Source/WebKit/UIProcess/Launcher/haiku/ProcessLauncherHaiku.cpp
@@ -152,6 +152,7 @@ void ProcessLauncher::launchProcess()
     entry_ref executableRef;
     if(GetRefForPath(executablePath, &executableRef) != B_OK)
     {
+        ASSERT_NOT_REACHED();
         return;
     }
 

--- a/Tools/MiniBrowser/haiku/CMakeLists.txt
+++ b/Tools/MiniBrowser/haiku/CMakeLists.txt
@@ -21,6 +21,11 @@ SET(MiniBrowser_LIBRARIES
     be bsd network stdc++ translation tracker
 )
 
+SET(MiniBrowser_DEPENDENCIES
+    NetworkProcess
+    WebProcess
+)
+
 set(MiniBrowser_LOCAL_INCLUDE_DIRECTORIES
     ${CMAKE_BINARY_DIR}
     "${WEBCORE_DIR}/css"
@@ -36,3 +41,4 @@ ADD_EXECUTABLE(MiniBrowser ${MiniBrowser_SOURCES})
 TARGET_LINK_LIBRARIES(MiniBrowser ${MiniBrowser_LIBRARIES})
 SET_TARGET_PROPERTIES(MiniBrowser PROPERTIES FOLDER "Tools")
 SET_TARGET_PROPERTIES(MiniBrowser PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+ADD_DEPENDENCIES(MiniBrowser ${MiniBrowser_DEPENDENCIES})


### PR DESCRIPTION
Also make MiniBrowser crash earlier if one of these executables is missing.