### PR TITLE
Disable message attachments

### DIFF
--- a/Source/WebKit/Platform/IPC/Attachment.h
+++ b/Source/WebKit/Platform/IPC/Attachment.h
@@ -50,7 +50,7 @@ struct Attachment { }; // Windows does not need attachments at the moment.
 #elif USE(UNIX_DOMAIN_SOCKETS)
 using Attachment = UnixFileDescriptor;
 #elif USE(HAIKU)
-using Attachment = int;
+struct Attachment { };
 #else
 #error Unsupported platform
 #endif


### PR DESCRIPTION
Haiku doesn't currently use attachments, so we may as well do what the Windows port does and make the attachment type an empty struct.

The previous message attachment type of int was causing WebProcess to crash when trying to decode an int in the message. Instead of decoding the int normally, it saw that the int was the attachment type and so tried to take an attachment from the message instead. But the message didn't have any attachments available, causing it to fail processing the message, leading to a crash.