### PR TITLE
Do not set drawing area size outside of main thread

### DIFF
--- a/Source/WebKit/UIProcess/API/haiku/PageClientImplHaiku.cpp
+++ b/Source/WebKit/UIProcess/API/haiku/PageClientImplHaiku.cpp
@@ -73,12 +73,10 @@ namespace WebKit
 
     WebCore::IntSize PageClientImpl::viewSize()
     {
-        if (fWebView.page()->drawingArea())
-        {
-            return fWebView.page()->drawingArea()->size();
-        }
-
-        return IntSize();
+        fWebView.Window()->Lock();
+        BRect rect = fWebView.Frame();
+        fWebView.Window()->Unlock();
+        return IntSize(rect.right - rect.left, rect.bottom - rect.top);
     }
 
     bool PageClientImpl::isViewWindowActive()

--- a/Source/WebKit/UIProcess/API/haiku/WebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/haiku/WebViewBase.cpp
@@ -57,7 +57,6 @@ WebViewBase::WebViewBase(const char* name, BRect rect, BWindow* parentWindow,
 
     if (fPage->drawingArea())
     {
-        setSize = true;
         fPage->drawingArea()->setSize(IntSize(rect.right - rect.left,
             rect.top - rect.bottom));
     }
@@ -84,11 +83,6 @@ void WebViewBase::Draw(BRect update)
     if (!drawingArea)
         return;
 
-    if (!setSize) {
-        setSize = true;
-        BRect rect = Frame();
-        drawingArea->setSize(IntSize(rect.right - rect.left, rect.bottom - rect.top));
-    }
     IntRect updateArea(update);
     WebCore::Region unpainted;
     drawingArea->paint(this, updateArea, unpainted);

--- a/Source/WebKit/UIProcess/API/haiku/WebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/haiku/WebViewBase.cpp
@@ -22,6 +22,7 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 #include "WebViewBase.h"
 #include "APIPageConfiguration.h"
 
@@ -41,7 +42,7 @@
 using namespace WebKit; 
 using namespace WebCore;
 
-WebKit::WebViewBase::WebViewBase(const char* name, BRect rect, BWindow* parentWindow,
+WebViewBase::WebViewBase(const char* name, BRect rect, BWindow* parentWindow,
     const API::PageConfiguration& pageConfig)
     : BView(name, B_WILL_DRAW | B_FRAME_EVENTS | B_FULL_UPDATE_ON_RESIZE),
     fPageClient(std::make_unique<PageClientImpl>(*this))

--- a/Source/WebKit/UIProcess/API/haiku/WebViewBase.h
+++ b/Source/WebKit/UIProcess/API/haiku/WebViewBase.h
@@ -63,8 +63,6 @@ namespace WebKit
 
             RefPtr<WebPageProxy> fPage;
             std::unique_ptr<PageClientImpl> fPageClient;
-
-            bool setSize {false};
     };
 }
 

--- a/Source/WebKit/UIProcess/API/haiku/WebViewBase.h
+++ b/Source/WebKit/UIProcess/API/haiku/WebViewBase.h
@@ -24,15 +24,12 @@
  */
 #pragma once
 
-#include <View.h>
-#include <Window.h>
-#include <Rect.h>
-
-#include "config.h"
-
 #include "APIObject.h"
 
-#include "WebCore/IntRect.h"
+#include <Rect.h>
+#include <View.h>
+#include <WebCore/IntRect.h>
+#include <Window.h>
 
 namespace API {
     class PageConfiguration;
@@ -53,7 +50,6 @@ namespace WebKit
                 return fWebView;
             }
             WebPageProxy* page() const { return fPage.get(); }
-            void initializeOnce();
             const char* currentURL();
 
             //hook methods


### PR DESCRIPTION
WebKit's UIProcess tends to want things to only be done from one thread. In our case, this is the BApplication thread. We were calling setSize from a BWindow thread. This lead to an assert testing whether we were on the right thread failing.

This change removes the call to setSize from WebViewBase::Draw. This fixes the crash, but also leaves the drawing area size at 0x0. The update to the definition of PageClientImpl::viewSize fixes this. It also seems like the correct definition of viewSize.