### PR TITLE
Always use CodePath::Simple to render fonts

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -616,6 +616,11 @@ FontCascade::CodePath FontCascade::codePath()
 
 FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<unsigned> from, std::optional<unsigned> to) const
 {
+#if PLATFORM(HAIKU)
+    // TODO: we only support the simple code path
+    return CodePath::Simple;
+#endif
+
     if (s_codePath != CodePath::Auto)
         return s_codePath;
 

--- a/Source/WebCore/platform/graphics/haiku/ComplexTextControllerHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/ComplexTextControllerHaiku.cpp
@@ -26,11 +26,18 @@
 #include "ComplexTextController.h"
 
 #include "FontCascade.h"
+#include "NotImplemented.h"
 
 namespace WebCore {
 
 void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const UChar> characters, unsigned stringLocation, const Font* font)
 {
+    // NOTE: if you implement this, you can probably stop FontCascade::codePath
+    // from always returning CodePath::Simple since we should then support the
+    // complex code path as well.
+    notImplemented();
+
+    // Create a run of missing glyphs from the primary font.
     m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters.data(), stringLocation, characters.size(), 0, characters.size(), m_run.ltr()));
 }
 

--- a/Source/WebCore/platform/graphics/haiku/FontCustomPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/haiku/FontCustomPlatformData.cpp
@@ -22,6 +22,7 @@
 #include "FontCustomPlatformData.h"
 
 #include "FontPlatformData.h"
+#include "NotImplemented.h"
 #include "SharedBuffer.h"
 
 #include "wtf/RefPtr.h"
@@ -77,6 +78,7 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
 bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)
 {
     // FIXME: define supported technologies for this platform (webkit.org/b/256310).
+    notImplemented();
     return true;
 }
 }

--- a/Source/WebCore/platform/graphics/haiku/FontHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/FontHaiku.cpp
@@ -42,14 +42,6 @@
 
 namespace WebCore {
 
-struct hack {
-    hack() {
-        /* We don't handle the complex text path yet, so just force the simple one */
-        FontCascade::setCodePath(FontCascade::CodePath::Simple);
-    }
-} hack;
-
-
 bool FontCascade::canReturnFallbackFontsForComplexText()
 {
     return false;


### PR DESCRIPTION
The hack in FontHaiku.cpp to set the code path to simple does not work for WebKit2 since WebKit2 sets the code path to CodePath::Auto later. Always returning CodePath::Simple from FontCascade::codePath works for WebKitLegacy and WebKit2.