### PR TITLE
Mark JSDOMWindow.cpp to not be bundled

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -70,7 +70,7 @@ On a gcc2hybrid (32bit) Haiku:
 
     $ PKG_CONFIG_LIBDIR=/boot/system/develop/lib/x86/pkgconfig \
         CC=gcc-x86 CXX=g++-x86 Tools/Scripts/build-webkit \
-        --cmakeargs="-DCMAKE_AR=/bin/ar-x86 -DCMAKE_RANLIB=/bin/ranlib-x86 -DCMAKE_CXX_FLAGS='-ftrack-macro-expansion=0 --param ggc-min-expand=10' -DENABLE_UNIFIED_BUILDS=0" --haiku \
+        --cmakeargs="-DCMAKE_AR=/bin/ar-x86 -DCMAKE_RANLIB=/bin/ranlib-x86 -DCMAKE_CXX_FLAGS='-ftrack-macro-expansion=0 --param ggc-min-expand=10'" --haiku \
         --no-fatal-warnings
 
 On other versions:

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3723,7 +3723,7 @@ JSDOMStringList.cpp
 JSDOMStringMap.cpp
 JSDOMTokenList.cpp
 JSDOMURL.cpp
-JSDOMWindow.cpp
+JSDOMWindow.cpp @no-unify
 JSDataCue.cpp
 JSDataTransfer.cpp
 JSDataTransferItem.cpp


### PR DESCRIPTION
Its complexity is big enough on its own when compiled on x86.

The script is changed so that, as a derived source not existing when it is run, it takes it anyway, creating a "bundle" that includes just that file and removing it from the one it would have been in.