### PR TITLE
Reduce complex text

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -44,6 +44,12 @@
 #include <CoreText/CoreText.h>
 #endif
 
+static void debugComplexText()
+{
+	if (strcmp(getenv("HAIKUWEBKIT_COMPLEX_TEXT"), "DEBUGGER") == 0)
+		debugger("Complex text path triggered");
+}
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ComplexTextController);
@@ -125,6 +131,8 @@ ComplexTextController::ComplexTextController(const FontCascade& font, const Text
     , m_forTextEmphasis(forTextEmphasis)
     , m_textSpacingState(run.textSpacingState())
 {
+    debugComplexText();
+
     computeExpansionOpportunity();
 
     collectComplexTextRuns();
@@ -138,6 +146,8 @@ ComplexTextController::ComplexTextController(const FontCascade& font, const Text
     , m_end(run.length())
     , m_expansion(run.expansion())
 {
+    debugComplexText();
+
     computeExpansionOpportunity();
 
     for (auto& run : runs)
@@ -151,6 +161,7 @@ ComplexTextController::ComplexTextController(const TextRun& run, const FontCasca
     , m_run(run)
     , m_end(run.length())
 {
+    debugComplexText();
 }
 
 std::pair<float, float> ComplexTextController::enclosingGlyphBoundsForTextRun(const FontCascade& fontCascade, const TextRun& textRun)

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -662,6 +662,9 @@ FontCascade::CodePath FontCascade::codePath(const TextRun& run, std::optional<un
 
 FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const UChar> span)
 {
+#if PLATFORM(HAIKU)
+	return CodePath::Simple;
+#endif
     // FIXME: Should use a UnicodeSet in ports where ICU is used. Note that we 
     // can't simply use UnicodeCharacter Property/class because some characters
     // are not 'combining', but still need to go to the complex path.

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -175,8 +175,13 @@ public:
     bool isFixedPitch() const;
     bool canTakeFixedPitchFastContentMeasuring() const;
     
+#if PLATFORM(HAIKU)
+    bool enableKerning() const { return false; }
+    bool requiresShaping() const { return false; }
+#else
     bool enableKerning() const { return m_enableKerning; }
     bool requiresShaping() const { return m_requiresShaping; }
+#endif
 
     const AtomString& firstFamily() const { return m_fontDescription.firstFamily(); }
     unsigned familyCount() const { return m_fontDescription.familyCount(); }


### PR DESCRIPTION
Disable complex text path in more cases and an environment variable protected call to debugger to detect issues that might be related to it.