### PR TITLE
FileSystemPOSIX: return temp dir in subsequent calls

### DIFF
--- a/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
+++ b/Source/WTF/wtf/posix/FileSystemPOSIX.cpp
@@ -172,8 +172,8 @@ static const char* temporaryFileDirectory()
         } else {
             strcpy(buffer, "/tmp");
         }
-        return buffer;
     }
+    return buffer;
 #else
     if (auto* tmpDir = getenv("TMPDIR"))
         return tmpDir;


### PR DESCRIPTION
After the first call it would fall down with no return instruction.