### PR TITLE
Fix build in nightlies

### DIFF
--- a/Source/WebCore/PAL/pal/PlatformHaiku.cmake
+++ b/Source/WebCore/PAL/pal/PlatformHaiku.cmake
@@ -11,4 +11,4 @@ list(APPEND PAL_SOURCES
     unix/LoggingUnix.cpp
 )
 
-list(APPEND PAL_LIBRARIES crypto)
+list(APPEND PAL_LIBRARIES crypto WTF)


### PR DESCRIPTION
I've been having a linking error and this solves it for me, though **I don't know why it happens to me and not the builder, and whether this is a proper solution**. The only difference I can think of is that I'm running nightly instead of beta.

```
[5738/5807] Linking CXX shared library lib/libWebKitLegacy.so.1.9.21
FAILED: lib/libWebKitLegacy.so.1.9.21 
/boot/system/develop/tools/bin/../lib/gcc/x86_64-unknown-haiku/13.3.0/../../../../x86_64-unknown-haiku/bin/ld: lib/../Source/WebCore/PAL/pal/CMakeFiles/PAL.dir/text/TextEncodingDetectorICU.cpp.o: in function `PAL::detectTextEncoding(std::span<unsigned char const, 18446744073709551615ul>, WTF::ASCIILiteral, PAL::TextEncoding*)':
TextEncodingDetectorICU.cpp:(.text._ZN3PAL18detectTextEncodingESt4spanIKhLm18446744073709551615EEN3WTF12ASCIILiteralEPNS_12TextEncodingE+0xa8): undefined reference to `WTF::ucsdet_detectAll_span(UCharsetDetector*, UErrorCode*)'
collect2: error: ld returned 1 exit status
```

`WTF::ucsdet_detectAll_span` is in `WTF/wtf/text/icu/UnicodeExtras`, declared with `WTF_EXPORT_PRIVATE` and called from `PAL::detectTextEncoding`. The failing command references `lib/libWTF.a` before `lib/libWTF.a`, and moving it afterwards finishes the build.