### PR TITLE
[curl] Set cookies for download requests

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlDownload.h
+++ b/Source/WebCore/platform/network/curl/CurlDownload.h
@@ -90,6 +90,7 @@ private:
 
     ResourceRequest m_request;
     ResourceResponse m_response;
+    ResourceHandle* m_resourceHandle { nullptr };
     bool m_deletesFileUponFailure { false };
     String m_destination;
     unsigned m_redirectCount { 0 };


### PR DESCRIPTION
Fixes download of attachments in anubis protected trac.

This is NOT the result of any understanding of how it should work. I failed hard when I tried, lost in the forest of loaders, handlers, delegates, raw/sub/cached resources and whatnot the execution goes through after clicking a link. The only clear information I got is that when it gets here, the request doesn't have the cookies header. For the download link option from the context menu it's more straightforward: a request is made from the URL and gets here quite directly, just URL and Accept-Language, without even User-Agent, Accept or Referer.