### PR TITLE
Fix crash on creation of blob from a canvas element

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -503,7 +503,7 @@ Vector<uint8_t> ImageBuffer::toData(Ref<ImageBuffer> source, const String& mimeT
         return { };
 #if USE(SKIA)
     return encodeData(*image, mimeType, quality);
-#elif USE(CG) || USE(CAIRO)
+#elif USE(CG) || USE(CAIRO) || USE(HAIKU)
     return encodeData(image->platformImage().get(), mimeType, quality);
 #endif
 }

--- a/Source/WebCore/platform/graphics/haiku/ImageBufferHaiku.cpp
+++ b/Source/WebCore/platform/graphics/haiku/ImageBufferHaiku.cpp
@@ -179,7 +179,7 @@ Vector<uint8_t> encodeData(BBitmap* bitmap, const String& mimeType, std::optiona
     uint32 translatorType = 0;
 
     BTranslatorRoster* roster = BTranslatorRoster::Default();
-    translator_id* translators;
+    translator_id* translators = NULL;
     int32 translatorCount;
     roster->GetAllTranslators(&translators, &translatorCount);
     for (int32 i = 0; i < translatorCount; i++) {
@@ -208,6 +208,7 @@ Vector<uint8_t> encodeData(BBitmap* bitmap, const String& mimeType, std::optiona
         if (translatorType)
             break;
     }
+    delete[] translators;
 
 
     BMallocIO translatedStream;


### PR DESCRIPTION
We have gotten away for too long with a no-return in that method.
There's also a leak fix in the related `encodeData`.